### PR TITLE
fix root links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 This exists as a record of otherwise ephemeral board games played amongst friends.
+
+## Setup
+
+- clone the repo
+- npm install
+- npm run server
+
+Make sure you have the same node installed as in [.tool-versions](https://github.com/team-combat/game-database/blob/master/.tool-versions)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "scripts": {
     "build": "node build-site.js && harp compile src build",
-    "test": "eslint ."
+    "test": "eslint .",
+    "server": "node build-site.js && harp server src"
   },
   "repository": {
     "type": "git",

--- a/src/_nav.ejs
+++ b/src/_nav.ejs
@@ -1,4 +1,8 @@
 <ul>
-  <li><a href="games">Game</a></li>
-  <li><a href="players">Player</a></li>
+  <%# these folders are dumb, but developing locally is at root and published
+  its at /game-database... must find fix later, too high %>
+  <li><a href="http://team-combat.github.io/game-database/games">Game</a></li>
+  <li>
+    <a href="http://team-combat.github.io/game-database/players">Player</a>
+  </li>
 </ul>


### PR DESCRIPTION
when developing, it's at `http://localhost:9000/`, but when published it's at `http://team-combat.github.io/game-database/` which has a different path root, so links that go to `/games` go to a different path entirely.